### PR TITLE
Add DuckDuckGo search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ python bot.py
 The bot uses OpenAI's `o3` model by default. Parameters for this model are
 configured in `DEFAULT_O3_PARAMS` within `bot.py`.
 When the bot is running, mention it with a question (e.g. `@YourBot what is 2+2?`) and it will reply.
+- The bot can now search the web via DuckDuckGo.
 
 ## GitHub Codespaces Quick Start
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai>=1.0.0
 discord.py
 python-dotenv
+httpx


### PR DESCRIPTION
## Summary
- enable httpx and create `do_search` helper
- declare `SEARCH_TOOL` schema for function-calling
- let `query_chatgpt` call DuckDuckGo when asked
- document new feature
- include httpx in requirements

## Testing
- `python -m py_compile bot.py`
