### PR TITLE
Add user-controlled search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python bot.py
 The bot uses OpenAI's `o3` model by default. Parameters for this model are
 configured in `DEFAULT_O3_PARAMS` within `bot.py`.
 When the bot is running, mention it with a question (e.g. `@YourBot what is 2+2?`) and it will reply.
-- The bot can now search the web via DuckDuckGo.
+- The bot can now search the web via DuckDuckGo. To force a web search, start your question with `search the internet` followed by the query.
 
 ## GitHub Codespaces Quick Start
 


### PR DESCRIPTION
## Summary
- add `force_search` support to `query_chatgpt`
- detect "search the internet" or "search the web" commands in messages
- document how to force a search via README

## Testing
- `python -m py_compile bot.py`