### PR TITLE
Fix link split when exceeding message cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - pre-commit hooks (Black, Ruff, EOF fixer)
 - Basic GitHub Actions CI (Black, Ruff, pytest).
+### Fixed
+- URLs are no longer split across message boundaries.
 
 ## [0.1.0] – 2025-05-20
 ### Added

--- a/src/discord_lm_bot/discord_bot.py
+++ b/src/discord_lm_bot/discord_bot.py
@@ -28,7 +28,7 @@ async def send_slow_message(channel, text, chunk=192, delay=1.0, max_len=2000):
             if hit_chunk:
                 if len(displayed) > max_len:
                     # provisional cut at Discord’s hard cap
-                    split_at = 1999
+                    split_at = max_len - 1
 
                     # walk backward for the last URL before the split point
                     last_url = None
@@ -36,7 +36,7 @@ async def send_slow_message(channel, text, chunk=192, delay=1.0, max_len=2000):
                         last_url = m
 
                     if last_url and last_url.end() > split_at:
-                        split_at = last_url.start() - 1
+                        split_at = max(0, last_url.start() - 1)
 
                     # if still mid-word, back up to previous space or period
                     if displayed[split_at].isalnum():


### PR DESCRIPTION
## Summary
- stop Discord URLs from being split mid-message
- document fix in the changelog

## Testing
- `black .`
- `ruff check . --fix`
- `pytest -q` *(fails: `pytest` not found)*