### PR TITLE
Add splitter tests and CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install deps
         run: |
-          python -m pip install -r requirements.txt pytest
+          python -m pip install -r requirements.txt pytest pytest-asyncio
       - name: Lint (Black)
         run: black --check .
       - name: Lint (Ruff)
         run: ruff check .
       - name: Tests
-        run: pytest -q || echo "pytest skipped (no tests yet)"
+        run: pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - pre-commit hooks (Black, Ruff, EOF fixer)
 - Basic GitHub Actions CI (Black, Ruff, pytest).
+- unit-tests for splitter (pytest).
 ### Fixed
 - URLs are no longer split across message boundaries.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-openai>=1.0.0
-discord.py
-python-dotenv
-httpx
 black
-ruff
+discord.py
+httpx
+openai>=1.0.0
 pre-commit
+pytest
+pytest-asyncio
+python-dotenv
+ruff

--- a/src/discord_lm_bot/discord_bot.py
+++ b/src/discord_lm_bot/discord_bot.py
@@ -60,6 +60,9 @@ async def send_slow_message(channel, text, chunk=192, delay=1.0, max_len=2000):
                 else:
                     await sent.edit(content=displayed)
                 await asyncio.sleep(delay)
+
+        if displayed:
+            await sent.edit(content=displayed)
     return sent
 
 

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -1,0 +1,65 @@
+import pytest
+
+from discord_lm_bot.discord_bot import send_slow_message
+
+
+class DummyMessage:
+    def __init__(self):
+        self.edits = []
+
+    async def edit(self, *, content=None):
+        self.edits.append(content)
+        return self
+
+
+class DummyChannel:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, text):
+        msg = DummyMessage()
+        self.sent.append(msg)
+        return msg
+
+    def typing(self):
+        class _CM:
+            async def __aenter__(self_inner):
+                return None
+
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                return False
+
+        return _CM()
+
+
+@pytest.mark.asyncio
+async def test_url_never_split():
+    prefix = "a" * 1995
+    url = "https://example.com/very-long-url"
+    suffix = "b" * (2100 - len(prefix) - len(url))
+    text = prefix + url + suffix
+
+    channel = DummyChannel()
+    await send_slow_message(channel, text, delay=0)
+
+    assert len(channel.sent) == 2
+    first_final = channel.sent[0].edits[-1]
+    second_first = channel.sent[1].edits[0]
+    assert "http" not in first_final
+    assert second_first.startswith("http")
+
+
+@pytest.mark.asyncio
+async def test_double_period_logic():
+    trail = "Blah blah. 4."
+    prefix = "a" * (1999 - trail.index("4"))
+    text = prefix + trail
+
+    channel = DummyChannel()
+    await send_slow_message(channel, text, delay=0)
+
+    assert len(channel.sent) == 2
+    first_final = channel.sent[0].edits[-1]
+    second_first = channel.sent[1].edits[0]
+    assert first_final.endswith("blah.")
+    assert second_first.startswith("4.")


### PR DESCRIPTION
## Summary
- add tests for URL-aware splitter
- fix `send_slow_message` so leftover text is delivered
- extend CI to run pytest directly
- document added tests in changelog
- add pytest dependencies

## Testing
- `black . && ruff check --fix .`
- `pytest -q` *(fails: command not found)*