### PR TITLE
Lazy init OpenAI client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic GitHub Actions CI (Black, Ruff, pytest).
 ### Fixed
 - URLs are no longer split across message boundaries.
+- OpenAI client initialised lazily; CI no longer needs API key.
 
 ## [0.1.0] – 2025-05-20
 ### Added

--- a/src/discord_lm_bot/discord_bot.py
+++ b/src/discord_lm_bot/discord_bot.py
@@ -69,7 +69,7 @@ async def query_chatgpt(prompt: str, model: str = "o3", **overrides) -> str:
     params = {k: v for k, v in merged.items() if v is not None}
 
     # 1st request – let the model decide if it needs search unless forced
-    r1 = await client_oai.chat.completions.create(
+    r1 = await client_oai().chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": prompt}],
         tools=[SEARCH_TOOL],
@@ -104,7 +104,7 @@ async def query_chatgpt(prompt: str, model: str = "o3", **overrides) -> str:
             ]
         )
 
-        r2 = await client_oai.chat.completions.create(
+        r2 = await client_oai().chat.completions.create(
             model=model,
             messages=history,
             **params,

--- a/src/discord_lm_bot/openai_client.py
+++ b/src/discord_lm_bot/openai_client.py
@@ -1,8 +1,13 @@
+from functools import cache
+import os
+
 from openai import AsyncOpenAI
 
-from .config import OPENAI_API_KEY
 
-client_oai = AsyncOpenAI(api_key=OPENAI_API_KEY)
+@cache
+def client_oai() -> AsyncOpenAI:
+    return AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY", "dummy"))
+
 
 DEFAULT_O3_PARAMS = {
     "temperature": 1,
@@ -18,3 +23,5 @@ SYSTEM_CITE = (
     "After answering, add a line 'Sources:' followed by every URL from "
     "web_search, one per line. Speak naturally."
 )
+
+__all__ = ["client_oai", "DEFAULT_O3_PARAMS", "SYSTEM_CITE"]


### PR DESCRIPTION
## Summary
- lazily initialize OpenAI client so tests don't need API key
- use `client_oai()` for chat completions
- note fix in changelog

## Testing
- `ruff check . --fix`
- `pytest -q` *(fails: command not found)*