### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__
+.venv
+.git
+.github
+.env
+*.pyc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,13 @@ jobs:
           OPENAI_API_KEY: "dummy"
         run: |
           python -m pytest -q || true
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build image (no push)
+        run: docker build -t discord-lm-app:ci-test .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pre-commit hooks (Black, Ruff, EOF fixer)
 - Basic GitHub Actions CI (Black, Ruff, pytest).
 - CONTRIBUTING and project state docs.
+- Dockerfile & docker-compose for one-command run.
+- CI job that builds the image.
 ### Fixed
 - URLs are no longer split across message boundaries.
 - OpenAI client initialised lazily; CI no longer needs an API key.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1.4
+FROM python:3.11-slim
+
+# System deps
+RUN apt-get update && apt-get install -y build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+# App code
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src/ ./src
+RUN pip install --no-cache-dir -e .
+
+# Entrypoint (env vars come from docker-compose)
+CMD ["python", "-m", "discord_lm_bot.discord_bot"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ This repository contains a simple Discord bot that connects to the OpenAI ChatGP
    ```
 6. Set `GOOGLE_API_KEY` and `GOOGLE_CSE_ID` in `.env` for web search.
 
+### Quick start with Docker
+
+```bash
+docker compose up --build -d        # first run
+docker compose logs -f bot          # view logs
+```
+
 ## Package Layout
 
 The bot code resides in `src/discord_lm_bot/`. Run the bot via `discord_lm_bot.run_bot`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+
+services:
+  bot:
+    build: .
+    env_file:
+      - .env               # same as local dev
+    restart: always
+    # comment out if running interactively
+    # logging:
+    #   driver: "json-file"
+    #   options:
+    #     max-size: "10m"
+    #     max-file: "3"


### PR DESCRIPTION
## Summary
- add Dockerfile, docker-compose and ignore file
- document Docker quick start
- update CI to build Docker image
- note Docker support in changelog

## Testing
- `black .`
- `ruff check . --fix`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord_lm_bot')*