### PR TITLE
Add MkDocs site scaffolding and docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,17 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Build image (no push)
         run: docker build -t discord-lm-app:ci-test .
+
+  docs-build:
+    runs-on: ubuntu-latest
+    needs: docker-build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install mkdocs
+        run: python -m pip install mkdocs-material mkdocstrings[python]
+      - name: Build docs
+        run: mkdocs build --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI job that builds the image.
 - mypy static-type checking (CI + pre-commit).
 - Structured Rich logging and exponential-back-off retries for OpenAI & Google calls.
+- MkDocs documentation site (Material theme) and CI build.
 ### Fixed
 - URLs are no longer split across message boundaries.
 - OpenAI client initialised lazily; CI no longer needs an API key.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -11,12 +11,12 @@
 - test-splitter-12
 - fix-ci-openai-24
 - logging-retry-15
+- docs-mkdocs-17
 
 ## Backlog
 | ID | Scope | Status |
 | dockerize-13 | Dockerfile & compose | next |
 | mypy-baseline-14 | add type hints & mypy | queued |
-| docs-mkdocs-17 | nice docs site | queued |
 | coverage-18 | pytest-cov, badge | queued |
 | dependabot-release-16 | weekly bumps, semantic-release | queued |
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Black](https://img.shields.io/badge/code%20style-black-000000)
 ![CI](https://github.com/<USER>/discord-lm-app/actions/workflows/ci.yml/badge.svg)
+![Docs](https://img.shields.io/badge/docs-site-blue)
 
 **• [CONTRIBUTING](CONTRIBUTING.md)** – dev setup & workflow  
 **• [Project state](PROJECT_STATE.md)** – architecture & roadmap
 
 This repository contains a simple Discord bot that connects to the OpenAI ChatGPT API. When a user @-mentions the bot, e.g. `@YourBot what is 2+2?`, the bot forwards the prompt to ChatGPT and replies with the response. The bot replies whenever it's mentioned in a message.
+Full documentation → <https://flimedime0.github.io/discord-lm-app/>
 
 ## Setup
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,8 @@
+# Configuration
+
+Set the following variables in your `.env` file:
+
+- `DISCORD_TOKEN` – Discord bot token
+- `OPENAI_API_KEY` – OpenAI API key
+- `GOOGLE_API_KEY` – Google API key
+- `GOOGLE_CSE_ID` – Google Custom Search Engine ID

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,6 @@
+# Development
+
+- Install pre-commit hooks with `pre-commit install`.
+- Run `black` and `ruff` before committing.
+- Ensure `pytest` and `mypy` pass.
+- CI checks formatting, types and tests.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# Discord LM Bot
+
+Welcome to the documentation for the ChatGPT Discord bot.
+This site provides usage instructions and development guidelines.
+
+- [Contributing](../CONTRIBUTING.md)
+- [Project state](../PROJECT_STATE.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,13 @@
+# Usage
+
+## Running with Python
+
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Configure your `.env` file.
+3. Start the bot with `python bot.py`.
+
+## Running with Docker
+
+```bash
+docker compose up --build -d
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,21 @@
+site_name: Discord LM Bot
+site_description: "Documentation for the ChatGPT Discord bot project"
+site_author: flimedime0
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - search.suggest
+repo_url: https://github.com/flimedime0/discord-lm-app
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight
+  - pymdownx.superfences

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 black
 discord.py
 httpx
+mkdocstrings[python]
+mkdocs-material
 mypy
 openai>=1.0.0
 pre-commit


### PR DESCRIPTION
## Summary
- add MkDocs dependencies
- create `mkdocs.yml` and documentation stubs
- add documentation build job to CI
- document docs site in CHANGELOG and PROJECT_STATE
- show docs badge and link in README

## Testing
- `black .`
- `ruff check . --fix`
- `pytest -q`
- `mypy .`
- `docker build` *(fails: `docker: command not found`)*
- `mkdocs build --strict` *(fails: `mkdocs: command not found`)*