### PR TITLE
Add coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,18 @@ jobs:
         run: ruff check .
       - name: Type check (mypy)
         run: mypy .
-      - name: Tests
+      - name: Tests + coverage
         env:
           OPENAI_API_KEY: "dummy"
         run: |
-          python -m pytest -q || true
+          pytest \
+            --cov=src/discord_lm_bot \
+            --cov-report=xml \
+            --cov-report=term
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          flags: unittests
 
   docker-build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - mypy static-type checking (CI + pre-commit).
 - Structured Rich logging and exponential-back-off retries for OpenAI & Google calls.
 - MkDocs documentation site (Material theme) and CI build.
+- Coverage reporting with pytest-cov + Codecov badge.
 ### Fixed
 - URLs are no longer split across message boundaries.
 - OpenAI client initialised lazily; CI no longer needs an API key.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![Black](https://img.shields.io/badge/code%20style-black-000000)
 ![CI](https://github.com/<USER>/discord-lm-app/actions/workflows/ci.yml/badge.svg)
 ![Docs](https://img.shields.io/badge/docs-site-blue)
+![Coverage](https://codecov.io/gh/flimedime0/discord-lm-app/branch/main/graph/badge.svg)
 
 **• [CONTRIBUTING](CONTRIBUTING.md)** – dev setup & workflow  
 **• [Project state](PROJECT_STATE.md)** – architecture & roadmap

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ mypy
 openai>=1.0.0
 pre-commit
 pytest
+pytest-cov
 pytest-asyncio
 python-dotenv
 rich


### PR DESCRIPTION
## Summary
- add pytest-cov dependency
- upload coverage reports in GitHub Actions
- show Codecov coverage badge
- document coverage reporting

## Testing
- `black .`
- `ruff check . --fix`
- `pytest -q`
- `mypy .`
