### PR TITLE
fix: fetch full history for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - URLs are no longer split across message boundaries.
 - OpenAI client initialised lazily; CI no longer needs an API key.
 - CI passes when no tests are collected.
+- Release workflow now fetches full git history (semantic-release works).
 
 ## [0.1.0] – 2025-05-20
 ### Added


### PR DESCRIPTION
## Summary
- unshallow the checkout in the release workflow
- document the release workflow fix in the changelog

## Testing
- `black .`
- `ruff check . --fix`
- `pytest -q`
- `mypy .`
