### PR TITLE
Finish automation loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,7 @@ jobs:
           python-version: '3.11'
       - name: Install mkdocs
         run: python -m pip install mkdocs-material mkdocstrings[python]
+      - name: Install link-checker plugin
+        run: python -m pip install mkdocs-link-check
       - name: Build docs
         run: mkdocs build --strict

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -1,0 +1,29 @@
+name: Issue sync
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  ensure-issue:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Ensure Task-ID issue exists & marked done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
+          # Expect titles like "dockerize-13: …"
+          ID=${TITLE%%:*}
+          [[ "$ID" == *"-"* ]] || exit 0   # skip if no Task-ID
+          # search for an existing issue
+          ISSUE=$(gh issue list -S "$ID in:title state:open" --json number -q '.[0].number' || true)
+          if [[ -z "$ISSUE" ]]; then
+            gh issue create -t "$ID" -b "Auto-created for completed PR ${{ github.event.pull_request.html_url }}" --label "Task-ID,status:done"
+          else
+            gh issue edit "$ISSUE" --add-label "status:done"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: semantic-release version && semantic-release publish
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push image
+        run: |
+          IMAGE=ghcr.io/${{ github.repository }}:${{ github.ref_name}}
+          docker build -t "$IMAGE" .
+          docker push "$IMAGE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## Unreleased
+
+### Added
+- MkDocs link-checker (CI fails on broken links)
+- Coverage guard (max –1 % drop)
+- Docker image pushed to GHCR on each release tag
+- Auto-creates / updates Task-ID Issues on PR merge
+- “Automation pipeline” docs page
+
 
 ## v0.1.0 (2025-05-21)
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@
 ![CI](https://github.com/<USER>/discord-lm-app/actions/workflows/ci.yml/badge.svg)
 ![Docs](https://img.shields.io/badge/docs-site-blue)
 ![Coverage](https://codecov.io/gh/flimedime0/discord-lm-app/branch/main/graph/badge.svg)
+![Image](https://img.shields.io/badge/docker-image-blue)
 ![Release](https://img.shields.io/github/v/release/flimedime0/discord-lm-app)
 
-**• [CONTRIBUTING](CONTRIBUTING.md)** – dev setup & workflow  
+**• [CONTRIBUTING](CONTRIBUTING.md)** – dev setup & workflow
 **• [Project state](PROJECT_STATE.md)** – architecture & roadmap
+*How the automation works →* `docs/automation.md`
 
 This repository contains a simple Discord bot that connects to the OpenAI ChatGPT API. When a user @-mentions the bot, e.g. `@YourBot what is 2+2?`, the bot forwards the prompt to ChatGPT and replies with the response. The bot replies whenever it's mentioned in a message.
 Full documentation → <https://flimedime0.github.io/discord-lm-app/>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,19 @@
+# Automation pipeline
+
+This project uses GitHub Actions for CI and release automation.
+
+CI stages run in sequence:
+1. Lint
+2. Tests
+3. Coverage check
+4. Docs build
+5. Docker build
+6. Release
+
+Dependabot sends weekly dependency bump PRs.
+
+semantic-release tags each version and publishes GitHub Releases.
+
+The roadmap-sync workflow rewrites `PROJECT_STATE.md` from issues.
+
+An auto-issue workflow ensures Task-ID issues exist and are marked done when PRs merge.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ plugins:
         python:
           options:
             docstring_style: google
+  - link-check
 markdown_extensions:
   - admonition
   - pymdownx.highlight

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,15 @@
 black
 discord.py
 httpx
-mkdocstrings[python]
+mkdocs-link-check
 mkdocs-material
+mkdocstrings[python]
 mypy
 openai>=1.0.0
 pre-commit
 pytest
-pytest-cov
 pytest-asyncio
+pytest-cov
 python-dotenv
 rich
 ruff


### PR DESCRIPTION
## Summary
- add mkdocs-link-check requirement
- enable link-check plugin in MkDocs
- add docs page on automation
- surface automation page link and Docker badge in README
- install link-checker plugin in CI
- enforce coverage guard with Codecov
- push docker image to GHCR on release
- auto-sync Task-ID issues when PRs merge
- document automation improvements in changelog

## Testing
- `pytest -q`
- `mypy .`
