### PR TITLE
Fix README CI badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 - De-duplicate `mkdocstrings[python]` and sort `requirements.txt`.
 
+### Documentation
+
+- Fix CI badge URL.
+
 ## v0.1.0 (2025-05-21)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Python 3.11](https://img.shields.io/badge/python-3.11-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Black](https://img.shields.io/badge/code%20style-black-000000)
-![CI](https://github.com/<USER>/discord-lm-app/actions/workflows/ci.yml/badge.svg)
+![CI](https://github.com/flimedime0/discord-lm-app/actions/workflows/ci.yml/badge.svg)
 ![Docs](https://img.shields.io/badge/docs-site-blue)
 ![Coverage](https://codecov.io/gh/flimedime0/discord-lm-app/branch/main/graph/badge.svg)
 ![Release](https://img.shields.io/github/v/release/flimedime0/discord-lm-app)


### PR DESCRIPTION
## Summary
- point CI badge URL at repo owner
- document badge fix in changelog

## Testing
- `pytest -q`
- `mypy .`
