### PR TITLE
CI docs: install link checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install mkdocs
-        run: python -m pip install mkdocs-material mkdocstrings[python]
+        - name: Install MkDocs deps
+          run: |
+            python -m pip install mkdocs-material \
+                               mkdocstrings[python] \
+                               mkdocs-linkcheck
       - name: Build docs
         run: mkdocs build --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Fix CI badge URL.
 
+### Fixed
+
+- Docs CI: install mkdocs-linkcheck plugin (build green)
+
 ## v0.1.0 (2025-05-21)
 
 ### Features


### PR DESCRIPTION
## Summary
- include `mkdocs-linkcheck` in the docs-build workflow
- note CI fix in CHANGELOG

## Testing
- `black .`
- `ruff check . --fix`
- `pytest -q`
- `mypy .`
