### PR TITLE
Add coverage guard and GHCR push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: semantic-release version && semantic-release publish
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push Docker image
+        run: |
+          IMAGE=ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          docker build -t "$IMAGE" .
+          docker push "$IMAGE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## Unreleased
 
+### Added
+
+- Coverage guard (CI fails if total coverage –1 % or more)
+- GHCR push: each release publishes a Docker image
+
 ### Chores
 
 - De-duplicate `mkdocstrings[python]` and sort `requirements.txt`.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,6 @@
+# Automation
+
+## CI stages
+
+* **Build** → verify formatting, tests and types
+* **Release tag** → Docker image auto-pushed to `ghcr.io/flimedime0/discord-lm-app:<tag>`


### PR DESCRIPTION
## Summary
- enforce coverage threshold via `codecov.yml`
- push Docker image to GHCR after every release
- document Docker image push in automation docs
- record automation updates in CHANGELOG

## Testing
- `black .`
- `ruff check . --fix`
- `pytest -q`
- `mypy .`
