### PR TITLE
fix release GHCR push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,6 +25,7 @@ jobs:
         run: semantic-release version && semantic-release publish
 
       - name: Log in to GHCR
+        if: github.ref_type == 'tag'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -31,7 +33,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push Docker image
+        if: github.ref_type == 'tag'
         run: |
-          IMAGE=ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          IMAGE=ghcr.io/${{ github.repository_owner }}/discord-lm-app:${{ github.ref_name }}
           docker build -t "$IMAGE" .
           docker push "$IMAGE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - Docs CI: install mkdocs-linkcheck plugin (build green)
+- Release workflow: GHCR push now succeeds (packages permission)
 
 ## v0.1.0 (2025-05-21)
 


### PR DESCRIPTION
## Notes
- Updated release workflow permissions and docker tag
- Documented fix in changelog

## Summary
- allow release workflow to push to GHCR using packages permission
- only login and push when running on tag

