### PR TITLE
Fix docs-build indentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-        - name: Install MkDocs deps
-          run: |
-            python -m pip install mkdocs-material \
-                               mkdocstrings[python] \
-                               mkdocs-linkcheck
+
+      - name: Install MkDocs deps
+        run: |
+          python -m pip install mkdocs-material \
+                             mkdocstrings[python] \
+                             mkdocs-linkcheck
       - name: Build docs
         run: mkdocs build --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### Continuous Integration
 
+- Fix docs-build indentation
+  ([`84fa128`](https://github.com/flimedime0/discord-lm-app/commit/84fa128))
+
 - Install linkcheck for docs
   ([`a7c716c`](https://github.com/flimedime0/discord-lm-app/commit/a7c716cf2309cff9e6f05145e963d5e1c6f05a18))
 


### PR DESCRIPTION
## Summary
- fix indentation in `docs-build` job in CI workflow
- note the fix in the changelog

## Testing
- `black .`
- `ruff check --fix .`
- `pytest -q`
- `mypy .`
