### PR TITLE
Add historical issue bootstrap script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # CHANGELOG
+## [Unreleased]
+
+## [0.1.1] - 2025-05-22
+### Added
+- Script tools/create_historical_issues.py to bootstrap roadmap from past changelog entries.
+
 
 
 ## v0.1.1 (2025-05-22)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,8 @@
 
 ## Releasing
 - bump CHANGELOG, tag once CI passes (semantic-release TBD)
+
+## Bootstrapping Historical Issues
+This project uses GitHub Issues to track tasks, which then auto-populates PROJECT_STATE.md.
+To create issues for work completed before this system was in place, run the `tools/create_historical_issues.py` script once from your Codespace terminal.
+Ensure you are authenticated with the gh CLI (`gh auth login`) and have write permissions for issues on this repository.

--- a/tools/create_historical_issues.py
+++ b/tools/create_historical_issues.py
@@ -1,0 +1,86 @@
+import re
+import subprocess
+import pathlib
+
+REPO = "flimedime0/discord-lm-app"
+
+KEYWORDS = [
+    "dockerize",
+    "mypy",
+    "coverage",
+    "dependabot",
+    "release",
+    "logging",
+    "docs-mkdocs",
+    "splitter",
+    "ci-fix",
+]
+
+
+def parse_changelog():
+    lines = pathlib.Path("CHANGELOG.md").read_text().splitlines()
+    sections = {"Unreleased": [], "0.1.0": []}
+    current_block = None
+    capture = False
+    for line in lines:
+        if line.startswith("## [Unreleased]"):
+            current_block = "Unreleased"
+            capture = False
+            continue
+        if re.match(r"## \[0\.1\.0\].*2025-05-20", line):
+            current_block = "0.1.0"
+            capture = False
+            continue
+        if line.startswith("## ") and current_block:
+            current_block = None
+            capture = False
+        if current_block:
+            if line.startswith("### "):
+                capture = any(k in line for k in ("Added", "Fixed"))
+                continue
+            if capture and line.startswith("- "):
+                sections[current_block].append(line[2:].strip())
+    return sections
+
+
+def extract_task_id(text: str) -> str | None:
+    m = re.search(r"\(([^()]+-\d+)\)", text)
+    if m:
+        return m.group(1)
+    lower = text.lower()
+    for kw in KEYWORDS:
+        if kw in lower:
+            return kw
+    return None
+
+
+def create_issues():
+    sections = parse_changelog()
+    for scope, items in sections.items():
+        for line in items:
+            tid = extract_task_id(line)
+            if tid:
+                title = f"{tid}: {line}"
+            else:
+                title = f"Historical Task: {line}"
+            print(f"Creating issue: {title}")
+            subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "create",
+                    "--title",
+                    title,
+                    "--body",
+                    "Auto-created from CHANGELOG.md for work completed around 2025-05-20/21.",
+                    "--label",
+                    "Task-ID,status:done",
+                    "--repo",
+                    REPO,
+                ],
+                check=False,
+            )
+
+
+if __name__ == "__main__":
+    create_issues()


### PR DESCRIPTION
## Summary
- add a helper `tools/create_historical_issues.py` to generate GitHub issues from the changelog
- document how to bootstrap historical issues in `CONTRIBUTING.md`
- record the script in `CHANGELOG.md`

## Testing
- `ruff check --fix .`
- `pytest -q`
- `mypy .`
