### PR TITLE
Use built-in token for issue sync

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -31,7 +35,7 @@ PY
       - name: Label and comment
         if: steps.task.outputs.id
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh api repos/${{ github.repository }}/issues/${{ steps.task.outputs.issue }}/labels -X PUT -f labels='["Task-ID","status:done"]'
           gh api repos/${{ github.repository }}/issues/${{ steps.task.outputs.issue }}/comments -f body="Closed by ${{ github.event.pull_request.html_url }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 - Wrap README badges in links.
 
+### Continuous Integration
+
+- Use built-in GITHUB_TOKEN in issue-sync
+
 ## v0.3.0 (2025-05-22)
 
 ### Documentation


### PR DESCRIPTION
## Summary
- add workflow permissions for issue sync
- switch issue sync auth to use `github.token`
- document the token change in the changelog

## Testing
- `black .`
- `ruff check . --fix`
- `pytest -q`
- `mypy .`
