### PR TITLE
CI: remove Python indentation in issue-sync

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -16,33 +16,24 @@ jobs:
 
       # 1 ▸ grab the Task ID out of the PR title
       - name: Extract Task ID from PR title
-        id: extract
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
+        id: task
         shell: bash
         run: |
-          ID=$(python - <<'PY'
-            import os, re, sys
-            title = os.getenv("PR_TITLE", "")
-            m = re.search(r'([a-z0-9\-]+-\d+)', title, re.I)
-            if m:
-                print(m.group(1))
-          PY
-          )
+          ID=$(grep -oE '([a-z0-9\-]+-\d+)' <<< "${{ github.event.pull_request.title }}" || true)
           echo "id=$ID" >>"$GITHUB_OUTPUT"
 
       # 2 ▸ ensure that issue exists (create if missing) and capture number
       - name: Ensure issue exists
-        if: ${{ steps.extract.outputs.id != '' }}
+        if: ${{ steps.task.outputs.id != '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          ISSUE=$(python tools/ensure_task_issue.py "${{ steps.extract.outputs.id }}")
+          ISSUE=$(python tools/ensure_task_issue.py "${{ steps.task.outputs.id }}")
           echo "issue=$ISSUE" >>"$GITHUB_OUTPUT"
 
       # 3 ▸ label & comment on the issue
       - name: Label and comment
-        if: ${{ steps.extract.outputs.id != '' }}
+        if: ${{ steps.task.outputs.id != '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Correct indentation and duplicate lines in `issue-sync.yml`; workflow now parses.
+- Remove indented here-doc in `issue-sync.yml`; workflow now runs without IndentationError.
 
 ## v0.3.2 (2025-05-22)
 


### PR DESCRIPTION
## Summary
- use `grep` instead of Python to extract Task ID
- update steps to reference `task`
- document fix in CHANGELOG

## Testing
- `black .`
- `ruff check . --fix`
- `pytest -q`
- `mypy .`
