### PR TITLE
chore: close Issue Sync loop (issue-sync-hardening-76)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "discord-lm-app",
   "image": "mcr.microsoft.com/devcontainers/python:3.11",
-  "postCreateCommand": "pip install -r requirements.txt && pre-commit install && black . && ruff --fix .",
+  "postCreateCommand": "bash scripts/dev-bootstrap.sh",
   "customizations": {
     "vscode": {
       "extensions": ["ms-python.python"]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 ### What’s inside
-- [ ] Implements **Task ID**: `<my-feature-99>`
+- [ ] **Task ID** in title, e.g. `feat: add weather cmd (weather-28)`
 - [ ] I wrote/updated tests
 - [ ] CI is green locally (`pre-commit run --all-files && pytest -q`)

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Ensure issue exists
         if: ${{ steps.task.outputs.id != '' }}
         env:
+          GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           ISSUE=$(python tools/ensure_task_issue.py "${{ steps.task.outputs.id }}")
@@ -35,6 +36,7 @@ jobs:
       - name: Label and comment
         if: ${{ steps.task.outputs.id != '' }}
         env:
+          GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           gh issue edit "$ISSUE" --add-label "Task-ID,status:done"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- Added one-shot `scripts/dev-bootstrap.sh` and dev-container hook.
+
 ### Fixed
 
 - Correct indentation and duplicate lines in `issue-sync.yml`; workflow now parses.
 - Remove indented here-doc in `issue-sync.yml`; workflow now runs without IndentationError.
+- Issue-Sync now authenticates with `GH_TOKEN`; requires Task ID in PR title.
 
 ## v0.3.2 (2025-05-22)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 - every change via Codex => paste instruction block, bring back diff pane
 - CI must be green before merge
 - every PR **must** include a Task ID and tests or a justification
+- **Add a Task ID** (`area-NN`) at the end of every PR title so Issue Sync can find or create the matching issue.
 
 ## Coding guidelines
 - Black line length 100, Ruff rules auto-fixed

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -10,6 +10,7 @@ This project uses several GitHub Actions workflows to keep everything in sync:
   * Executes unit tests with **Pytest** and uploads coverage to Codecov.
   * Builds the Docker image (without pushing).
   * Builds the documentation site and checks external links.
+  * If a PR title contains a Task ID, the Issue Sync job automatically opens/labels the matching issue when the PR is merged.
 * **Release workflow** (`.github/workflows/release.yml`)
   * Triggers when a pull request is merged into `main`.
   * Uses **python-semantic-release** to bump the version and update `CHANGELOG.md`.

--- a/scripts/dev-bootstrap.sh
+++ b/scripts/dev-bootstrap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# One-liner dev setup for new contributors
+set -e
+python -m pip install -r requirements.txt
+python -m pip install -e ".[dev]"
+pre-commit install
+echo "✅  Environment ready – run: pytest -q"


### PR DESCRIPTION
## Summary
- authenticate issue sync steps with `GH_TOKEN`
- clarify Task ID usage in PR template and CONTRIBUTING guide
- add `scripts/dev-bootstrap.sh` and wire up devcontainer
- document dev bootstrap in CI docs
- explain Issue Sync automation
- update changelog

## Testing
- `black .`
- `ruff check . --fix`
- `pytest -q`
- `mypy .`
