### PR TITLE
title-lint-77: add PR title lint workflow

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,23 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title for Task ID
+        shell: bash
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          if grep -qE '([a-z0-9\-]+-\d+)' <<< "$TITLE"; then
+            echo "Found Task ID in title"
+          else
+            echo "Pull request title must contain a Task ID like my-feature-99" >&2
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- PR-title lint workflow prevents merges without a Task ID.
+
 ### Fixed
 
 - Correct indentation and duplicate lines in `issue-sync.yml`; workflow now parses.


### PR DESCRIPTION
## Summary
- add workflow to block PRs missing Task ID
- document the workflow in the changelog

## Testing
- `black .`
- `ruff check --fix .`
- `pytest -q`
- `mypy .`
