### PR TITLE
fix(tools): fix-roadmap-script-labels-83 - handle labels as objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [Unreleased]
+
+### Fixed
+- Correctly access label names in update_state.py to fix roadmap sync
 
 ## v0.3.6 (2025-05-23)
 

--- a/tools/update_state.py
+++ b/tools/update_state.py
@@ -31,7 +31,11 @@ def fetch_issues():
 buckets: dict[str, list[str]] = {"in-progress": [], "todo": [], "done": []}
 for it in fetch_issues():
     status = next(
-        (label.split(":", 1)[1] for label in it["labels"] if label.startswith("status:")),
+        (
+            lbl_obj["name"].split(":", 1)[1]
+            for lbl_obj in it["labels"]
+            if lbl_obj["name"].startswith("status:")
+        ),
         "todo",
     )
     buckets[status].append(it["title"])


### PR DESCRIPTION
## Summary
- correctly access label names in `update_state.py`
- document the fix in the changelog

## Testing
- `black .`
- `ruff check . --fix`
- `mypy .`
- `pytest -q`
