### PR TITLE
fix(bot): Update /chat options and remove emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Changed
 - Consolidated model selection into /chat; mention now appears at message end; added typing indicator in DMs. (feature-chat-simplify-02)
+- Added model override choices for /chat and removed emoji from warnings.
 
 
 ## v0.3.7 (2025-05-23)

--- a/src/discord_lm_bot/discord_bot.py
+++ b/src/discord_lm_bot/discord_bot.py
@@ -74,10 +74,18 @@ async def query_chatgpt(
 
 @tree.command(name="chat", description="Send a prompt to the AI model in servers or DMs.")
 @app_commands.describe(prompt="The prompt or question for the AI.")
+@app_commands.describe(model="Optional model override")
+@app_commands.choices(
+    model=[
+        app_commands.Choice(name="gpt-4o", value="gpt-4o"),
+        app_commands.Choice(name="o3", value="o3"),
+    ]
+)
 @app_commands.allowed_installs(guilds=True, users=True)
 @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
 async def slash_chat(
     interaction: discord.Interaction,
+    *,
     prompt: str,
     model: app_commands.Choice[str] | None = None,
 ):
@@ -98,7 +106,7 @@ async def slash_chat(
 
         if len(all_attachments) > 10:
             await interaction.followup.send(
-                "\u26a0\ufe0f Only the first 10 images were processed; the rest were ignored.",
+                "Only the first 10 images were processed; the rest were ignored.",
                 ephemeral=True,
             )
 

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -14,9 +14,9 @@ def test_split_message_no_blank_segment():
 
 
 def test_split_message_unicode_and_urls():
-    text = "🙂" * 1000 + " https://example.com/foo" + " bar"
+    text = "あ" * 1000 + " https://example.com/foo" + " bar"
     parts = split_message(text, max_len=1005)
-    assert parts == ["🙂" * 1000, "https://example.com/foo bar"]
+    assert parts == ["あ" * 1000, "https://example.com/foo bar"]
 
 
 def test_split_message_no_break_space():


### PR DESCRIPTION
## Summary
- support model override choices for `/chat`
- clean up emoji usage in bot and tests
- tweak tests for unicode handling

## Testing
- `black . --quiet`
- `ruff check . --fix`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e229d38748320ae8e109ca636817d